### PR TITLE
fix: Include the Printer mib to pass the config-test

### DIFF
--- a/etc/datacollection-config.xml
+++ b/etc/datacollection-config.xml
@@ -14,6 +14,7 @@
       <include-collection dataCollectionGroup="Juniper"/>
       <include-collection dataCollectionGroup="Net-SNMP"/>
       <include-collection dataCollectionGroup="OpenNMS Appliances"/>
+      <include-collection dataCollectionGroup="Printers"/>
       <include-collection dataCollectionGroup="Routers"/>
    </snmp-collection>
 </datacollection-config>


### PR DESCRIPTION
We load the resource-types.d from the default configuration which has a reference to the printer mib. We need to include the Printers collection group in the datacollection-config.xml.

Resolve: #1